### PR TITLE
[PO-30] Using NTP for time synchronization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ val dep = {
     "io.circe" %% "circe-parser" % circeVersion,
     "io.circe" %% "circe-generic-extras" % circeVersion,
     "com.miguno.akka" %% "akka-mock-scheduler" % "0.5.1" % "it,test",
-    "commons-io" % "commons-io" % "2.5"
+    "commons-io" % "commons-io" % "2.5",
+    "commons-net" % "commons-net" % "3.4"
   )
 }
 

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -19,6 +19,8 @@ abstract class ScenarioSetup(scenario: BlockchainScenario)
   with ElectionManagerBuilder
   with SlotTimeConverterBuilder
   with ValidatorsBuilder
+  with ClockBuilder
+  with NTPBuilder
   with SyncConfigBuilder
   with BlockchainConfigBuilder
   with OuroborosConfigBuilder {

--- a/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
+++ b/src/ets/scala/io/iohk/ethereum/ets/blockchain/ScenarioSetup.scala
@@ -20,7 +20,7 @@ abstract class ScenarioSetup(scenario: BlockchainScenario)
   with SlotTimeConverterBuilder
   with ValidatorsBuilder
   with ClockBuilder
-  with NTPBuilder
+  with NTPServiceBuilder
   with SyncConfigBuilder
   with BlockchainConfigBuilder
   with OuroborosConfigBuilder {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -444,6 +444,12 @@ mantis {
     # Duration of each slot
     slot-duration = 5.seconds
   }
+
+  ntp {
+    ntp-server = "pool.ntp.org"
+
+    update-offset-interval = 10.minutes
+  }
 }
 
 akka {

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -34,7 +34,7 @@ import io.iohk.ethereum.validators._
 import io.iohk.ethereum.vm.VM
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.pos.ElectionManagerImpl
-import io.iohk.ethereum.timing.{BeaconActor, Clock, SystemClock}
+import io.iohk.ethereum.timing.{BeaconActor, Clock, NTPClock}
 import io.iohk.ethereum.utils.Config.SyncConfig
 
 import scala.concurrent.duration._
@@ -470,9 +470,9 @@ trait SlotTimeConverterBuilder {
 }
 
 trait ClockBuilder {
-  self: NTPBuilder =>
+  self: NTPServiceBuilder =>
 
-  lazy val clock: Clock = SystemClock(ntp)
+  lazy val clock: Clock = NTPClock(ntpService)
 }
 
 trait BeaconActorBuilder {
@@ -491,11 +491,11 @@ trait BeaconActorBuilder {
     clock), "beacon")
 }
 
-trait NTPBuilder {
+trait NTPServiceBuilder {
 
-  private lazy val ntpConfig = NTPConfig(Config.config)
+  private lazy val ntpServiceConfig = NTPServiceConfig(Config.config)
 
-  lazy val ntp = new NTP(ntpConfig)
+  lazy val ntpService = new NTPService(ntpServiceConfig)
 
 }
 
@@ -544,5 +544,5 @@ trait Node extends NodeKeyBuilder
   with ProofOfStakeMinerBuilder
   with SlotTimeConverterBuilder
   with BeaconActorBuilder
-  with NTPBuilder
+  with NTPServiceBuilder
   with ClockBuilder

--- a/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
+++ b/src/main/scala/io/iohk/ethereum/nodebuilder/NodeBuilder.scala
@@ -34,7 +34,7 @@ import io.iohk.ethereum.validators._
 import io.iohk.ethereum.vm.VM
 import io.iohk.ethereum.ommers.OmmersPool
 import io.iohk.ethereum.pos.ElectionManagerImpl
-import io.iohk.ethereum.timing.BeaconActor
+import io.iohk.ethereum.timing.{BeaconActor, Clock, SystemClock}
 import io.iohk.ethereum.utils.Config.SyncConfig
 
 import scala.concurrent.duration._
@@ -359,11 +359,12 @@ trait OmmersPoolBuilder {
 trait ValidatorsBuilder {
   self: BlockchainConfigBuilder
     with ElectionManagerBuilder
-    with SlotTimeConverterBuilder =>
+    with SlotTimeConverterBuilder
+    with ClockBuilder =>
 
   lazy val validators = new Validators {
     val blockValidator: BlockValidator = BlockValidator
-    val blockHeaderValidator: BlockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig, electionManager, slotTimeConverter)
+    val blockHeaderValidator: BlockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig, electionManager, slotTimeConverter, clock)
     val ommersValidator: OmmersValidator = new OmmersValidatorImpl(blockchainConfig, blockHeaderValidator)
     val signedTransactionValidator: SignedTransactionValidator = new SignedTransactionValidatorImpl(blockchainConfig)
   }
@@ -468,18 +469,34 @@ trait SlotTimeConverterBuilder {
   lazy val slotTimeConverter: SlotTimeConverter = SlotTimeConverter(ouroborosConfig, slot1StartingTime)
 }
 
+trait ClockBuilder {
+  self: NTPBuilder =>
+
+  lazy val clock: Clock = SystemClock(ntp)
+}
+
 trait BeaconActorBuilder {
   self: ActorSystemBuilder
     with BlockchainBuilder
     with ProofOfStakeMinerBuilder
-    with OuroborosConfigBuilder =>
+    with OuroborosConfigBuilder
+    with ClockBuilder =>
 
   private lazy val systemStartTime: FiniteDuration = genesisTimestamp.seconds
 
   lazy val beacon: ActorRef = actorSystem.actorOf(BeaconActor.props(
     miner,
     ouroborosConfig.slotDuration,
-    systemStartTime), "beacon")
+    systemStartTime,
+    clock), "beacon")
+}
+
+trait NTPBuilder {
+
+  private lazy val ntpConfig = NTPConfig(Config.config)
+
+  lazy val ntp = new NTP(ntpConfig)
+
 }
 
 trait Node extends NodeKeyBuilder
@@ -527,3 +544,5 @@ trait Node extends NodeKeyBuilder
   with ProofOfStakeMinerBuilder
   with SlotTimeConverterBuilder
   with BeaconActorBuilder
+  with NTPBuilder
+  with ClockBuilder

--- a/src/main/scala/io/iohk/ethereum/timing/BeaconActor.scala
+++ b/src/main/scala/io/iohk/ethereum/timing/BeaconActor.scala
@@ -10,16 +10,15 @@ import scala.concurrent.duration._
 class BeaconActor(
   miner: ActorRef,
   slotDuration: FiniteDuration,
-  systemStartTime: FiniteDuration = System.currentTimeMillis.millis,
-  externalSchedulerOpt: Option[Scheduler] = None,
-  clockOpt: Option[Clock] = None)
+  systemStartTime: FiniteDuration,
+  clock: Clock,
+  externalSchedulerOpt: Option[Scheduler] = None)
   extends Actor
     with ActorLogging {
 
   import BeaconActor._
 
   private def scheduler: Scheduler = externalSchedulerOpt getOrElse context.system.scheduler
-  private def clock: Clock = clockOpt getOrElse SystemClock
 
   private def prunePastSlots(slotList: SlotList, currentTime: FiniteDuration): SlotList = slotList.dropWhile {
     slot =>
@@ -51,7 +50,7 @@ class BeaconActor(
       val slot = slotList.head
       log.debug(s"Processing slot ${slot.number}")
 
-      val currentTime = clock.now
+      val currentTime = clock.now()
       val delay = 0.millis max slot.startTime - currentTime
       log.debug(s"Slot start time is ${slot.startTime}, current time is $currentTime, so waiting for $delay")
 
@@ -71,15 +70,15 @@ object BeaconActor {
   def props(
     miner: ActorRef,
     slotDuration: FiniteDuration,
-    systemStartTime: FiniteDuration = System.currentTimeMillis.millis,
-    externalSchedulerOpt: Option[Scheduler] = None,
-    clockOpt: Option[Clock] = None): Props =
+    systemStartTime: FiniteDuration,
+    clock: Clock,
+    externalSchedulerOpt: Option[Scheduler] = None): Props =
     Props(new BeaconActor(
       miner,
       slotDuration,
       systemStartTime,
-      externalSchedulerOpt,
-      clockOpt)
+      clock,
+      externalSchedulerOpt)
     )
 
   val startingSlotNumber = 1

--- a/src/main/scala/io/iohk/ethereum/timing/NTPClock.scala
+++ b/src/main/scala/io/iohk/ethereum/timing/NTPClock.scala
@@ -1,0 +1,9 @@
+package io.iohk.ethereum.timing
+
+import io.iohk.ethereum.utils.NTPService
+
+import scala.concurrent.duration._
+
+case class NTPClock(ntpService: NTPService) extends Clock {
+  override def now(): FiniteDuration = ntpService.correctedTime()
+}

--- a/src/main/scala/io/iohk/ethereum/timing/SystemClock.scala
+++ b/src/main/scala/io/iohk/ethereum/timing/SystemClock.scala
@@ -1,8 +1,9 @@
 package io.iohk.ethereum.timing
 
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import io.iohk.ethereum.utils.NTP
 
+import scala.concurrent.duration._
 
-object SystemClock extends Clock {
-  override def now(): FiniteDuration = FiniteDuration(System.currentTimeMillis(), MILLISECONDS)
+case class SystemClock(ntp: NTP) extends Clock {
+  override def now(): FiniteDuration = ntp.correctedTime().millis
 }

--- a/src/main/scala/io/iohk/ethereum/timing/SystemClock.scala
+++ b/src/main/scala/io/iohk/ethereum/timing/SystemClock.scala
@@ -1,9 +1,0 @@
-package io.iohk.ethereum.timing
-
-import io.iohk.ethereum.utils.NTP
-
-import scala.concurrent.duration._
-
-case class SystemClock(ntp: NTP) extends Clock {
-  override def now(): FiniteDuration = ntp.correctedTime().millis
-}

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -416,3 +416,18 @@ object OuroborosConfig {
     }
   }
 }
+
+trait NTPConfig {
+  val ntpServer: String
+  val updateOffsetInterval: FiniteDuration
+}
+
+object NTPConfig {
+  def apply(etcClientConfig: com.typesafe.config.Config): NTPConfig = {
+    val ntpConfig = etcClientConfig.getConfig("ntp")
+    new NTPConfig {
+      override val ntpServer: String = ntpConfig.getString("ntp-server")
+      override val updateOffsetInterval: FiniteDuration = ntpConfig.getDuration("update-offset-interval").toMillis.millis
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/utils/Config.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/Config.scala
@@ -417,15 +417,15 @@ object OuroborosConfig {
   }
 }
 
-trait NTPConfig {
+trait NTPServiceConfig {
   val ntpServer: String
   val updateOffsetInterval: FiniteDuration
 }
 
-object NTPConfig {
-  def apply(etcClientConfig: com.typesafe.config.Config): NTPConfig = {
+object NTPServiceConfig {
+  def apply(etcClientConfig: com.typesafe.config.Config): NTPServiceConfig = {
     val ntpConfig = etcClientConfig.getConfig("ntp")
-    new NTPConfig {
+    new NTPServiceConfig {
       override val ntpServer: String = ntpConfig.getString("ntp-server")
       override val updateOffsetInterval: FiniteDuration = ntpConfig.getDuration("update-offset-interval").toMillis.millis
     }

--- a/src/main/scala/io/iohk/ethereum/utils/NTP.scala
+++ b/src/main/scala/io/iohk/ethereum/utils/NTP.scala
@@ -1,0 +1,53 @@
+package io.iohk.ethereum.utils
+
+import java.net.InetAddress
+
+import org.apache.commons.net.ntp.NTPUDPClient
+
+import scala.util.Try
+
+// NTP implementation copied from Scorex
+//  https://github.com/input-output-hk/Scorex/blob/master/scorex-basics/src/main/scala/scorex/utils/NTP.scala
+class NTP(ntpConfig: NTPConfig) extends Logger {
+  private val TimeTillUpdateMillis = ntpConfig.updateOffsetInterval.toMillis
+  private val NTPServer = ntpConfig.ntpServer
+  private val NTPClientDefaultTimeout = 10000
+
+  private var lastUpdate = 0L
+  private var offset = 0L
+
+  def correctedTime(): Long = {
+    //CHECK IF OFFSET NEEDS TO BE UPDATED
+    if (System.currentTimeMillis() > lastUpdate + TimeTillUpdateMillis) {
+      Try {
+        updateOffSet()
+        lastUpdate = System.currentTimeMillis()
+
+        log.debug("Adjusting time with " + offset + " milliseconds.")
+      } recover {
+        case e: Throwable =>
+          log.warn("Unable to get corrected time", e)
+      }
+    }
+
+    //CALCULATE CORRECTED TIME
+    System.currentTimeMillis() + offset
+  }
+
+  private def updateOffSet() {
+    val client = new NTPUDPClient()
+    client.setDefaultTimeout(NTPClientDefaultTimeout)
+
+    try {
+      client.open()
+
+      val info = client.getTime(InetAddress.getByName(NTPServer))
+      info.computeDetails()
+      if (Option(info.getOffset).isDefined) offset = info.getOffset
+    } catch {
+      case t: Throwable => log.warn("Problems with NTP: ", t)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
+++ b/src/main/scala/io/iohk/ethereum/validators/BlockHeaderValidator.scala
@@ -3,6 +3,7 @@ package io.iohk.ethereum.validators
 import akka.util.ByteString
 import io.iohk.ethereum.domain._
 import io.iohk.ethereum.pos.ElectionManager
+import io.iohk.ethereum.timing.Clock
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig}
 
 trait BlockHeaderValidator {
@@ -21,7 +22,8 @@ object BlockHeaderValidatorImpl {
 
 class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig,
                                electionManager: ElectionManager,
-                               slotTimeConverter: SlotTimeConverter) extends BlockHeaderValidator {
+                               slotTimeConverter: SlotTimeConverter,
+                               clock: Clock) extends BlockHeaderValidator {
 
   import BlockHeaderValidatorImpl._
   import BlockHeaderError._
@@ -182,7 +184,7 @@ class BlockHeaderValidatorImpl(blockchainConfig: BlockchainConfig,
     */
   private def validateSlotNumber(blockHeader: BlockHeader, parentHeader: BlockHeader): Either[BlockHeaderError, BlockHeaderValid] = {
     val blockSlotBeginningTimeMillis = slotTimeConverter.getSlotStartingMillis(blockHeader.slotNumber)
-    val currentTimeMillis = System.currentTimeMillis()
+    val currentTimeMillis = clock.now().toMillis
 
     val isAfterParent = blockHeader.slotNumber > parentHeader.slotNumber
     val isFromFuture = currentTimeMillis < blockSlotBeginningTimeMillis

--- a/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
+++ b/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
@@ -49,7 +49,7 @@ class Prerequisites(config: Config) {
   val sourceBlockchain = BlockchainImpl(sourceStorages.storages)
   val targetBlockchain = targetStorages.map(ts => BlockchainImpl(ts.storages))
 
-  private val components = new ValidatorsBuilder with ClockBuilder with NTPBuilder
+  private val components = new ValidatorsBuilder with ClockBuilder with NTPServiceBuilder
                               with BlockchainConfigBuilder with SyncConfigBuilder
                               with ElectionManagerBuilder with SlotTimeConverterBuilder
                               with OuroborosConfigBuilder with BlockchainBuilder with StorageBuilder {

--- a/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
+++ b/src/snappy/scala/io/iohk/ethereum/snappy/Prerequisites.scala
@@ -49,7 +49,8 @@ class Prerequisites(config: Config) {
   val sourceBlockchain = BlockchainImpl(sourceStorages.storages)
   val targetBlockchain = targetStorages.map(ts => BlockchainImpl(ts.storages))
 
-  private val components = new ValidatorsBuilder with BlockchainConfigBuilder with SyncConfigBuilder
+  private val components = new ValidatorsBuilder with ClockBuilder with NTPBuilder
+                              with BlockchainConfigBuilder with SyncConfigBuilder
                               with ElectionManagerBuilder with SlotTimeConverterBuilder
                               with OuroborosConfigBuilder with BlockchainBuilder with StorageBuilder {
     override lazy val blockchain = sourceBlockchain

--- a/src/test/scala/io/iohk/ethereum/domain/SlotTimeConverterSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/domain/SlotTimeConverterSpec.scala
@@ -10,9 +10,8 @@ class SlotTimeConverterSpec extends FlatSpec with Matchers with PropertyChecks {
 
   it should "correctly obtain the slot beginning timestamp for each slot greater than 0" in {
 
-    val slotDurationMillis = 1000
     val ouroborosConfig = new OuroborosConfig {
-      val slotDuration: FiniteDuration = slotDurationMillis.millis
+      val slotDuration: FiniteDuration = 2.seconds
 
       //unused
       val knownStakeholders: Seq[Address] = Nil
@@ -23,10 +22,10 @@ class SlotTimeConverterSpec extends FlatSpec with Matchers with PropertyChecks {
 
     val table = Table[Int, Int](
       ("slotNumber", "slotBeginningSeconds"),
-      (1, 1000),
-      (2, 2000),
-      (10, 10000),
-      (13, 13000)
+      (1, 1),
+      (2, 3),
+      (10, 19),
+      (13, 25)
     )
 
     forAll(table){ (slotNumber, slotBeginningSeconds) =>

--- a/src/test/scala/io/iohk/ethereum/timing/BeaconActorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/timing/BeaconActorSpec.scala
@@ -68,5 +68,5 @@ class TestSetup extends MockFactory {
   val clockMock = mock[Clock]
   val systemStartTime = System.currentTimeMillis.millis
   val beacon = TestActorRef(Props(new BeaconActor(
-    minerMock.ref, slotDuration, systemStartTime, Some(schedulerMock), Some(clockMock))))
+    minerMock.ref, slotDuration, systemStartTime, clockMock, Some(schedulerMock))))
 }

--- a/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
+++ b/src/test/scala/io/iohk/ethereum/validators/BlockHeaderValidatorSpec.scala
@@ -5,6 +5,7 @@ import io.iohk.ethereum.{Fixtures, ObjectGenerators}
 import io.iohk.ethereum.blockchain.sync.EphemBlockchainTestSetup
 import io.iohk.ethereum.domain.{UInt256, _}
 import io.iohk.ethereum.pos.ElectionManagerImpl
+import io.iohk.ethereum.timing.Clock
 import io.iohk.ethereum.utils.{BlockchainConfig, DaoForkConfig, MonetaryPolicyConfig}
 import io.iohk.ethereum.validators.BlockHeaderError._
 import org.scalatest.prop.PropertyChecks
@@ -13,11 +14,14 @@ import org.spongycastle.util.encoders.Hex
 import io.iohk.ethereum.validators.BlockHeaderValidatorImpl._
 import org.scalamock.scalatest.MockFactory
 
+import scala.concurrent.duration._
+
 class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyChecks with ObjectGenerators with MockFactory {
 
   "BlockHeaderValidator" should "validate correctly formed BlockHeaders" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*, *).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     blockHeaderValidator.validate(validBlockHeader, validBlockParent) match {
       case Right(_) => succeed
@@ -27,7 +31,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid extra data" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     forAll(randomSizeByteStringGen(
       MaxExtraDataSize + 1,
@@ -41,7 +46,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
   it should "validate DAO block (extra data)" in new TestSetup {
     import Fixtures.Blocks._
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     val cases = Table(
       ("Block", "Parent Block", "Supports Dao Fork", "Valid"),
@@ -57,7 +63,7 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
     )
 
     forAll(cases) { (block, parentBlock, supportsDaoFork, valid ) =>
-      val blockHeaderValidator = new BlockHeaderValidatorImpl(createBlockchainConfig(supportsDaoFork), electionManagerMock, slotCalculatorMock)
+      val blockHeaderValidator = new BlockHeaderValidatorImpl(createBlockchainConfig(supportsDaoFork), electionManagerMock, slotCalculatorMock, clockMock)
       blockHeaderValidator.validate(block, parentBlock) match {
         case Right(_) => assert(valid)
         case Left(DaoHeaderExtraDataError) => assert(!valid)
@@ -68,7 +74,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid timestamp" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     forAll(longGen) { timestamp =>
       val blockHeader = validBlockHeader.copy(unixTimestamp = timestamp)
@@ -82,7 +89,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid difficulty" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     forAll(bigIntGen) { difficulty =>
       val blockHeader = validBlockHeader.copy(difficulty = difficulty)
@@ -94,7 +102,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid gas used" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     forAll(bigIntGen) { gasUsed =>
       val blockHeader = validBlockHeader.copy(gasUsed = gasUsed)
@@ -106,7 +115,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid gas limit" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     val LowerGasLimit = MinGasLimit.max(
       validBlockParent.gasLimit - validBlockParent.gasLimit / GasLimitBoundDivisor + 1)
@@ -123,7 +133,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created with gas limit above threshold and block number >= eip106 block number" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     val validParent = validBlockParent.copy(gasLimit = Long.MaxValue)
     val invalidBlockHeader = validBlockHeader.copy(gasLimit = BigInt(Long.MaxValue) + 1)
@@ -132,7 +143,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if created based on invalid number" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     forAll(longGen) { number =>
       val blockHeader = validBlockHeader.copy(number = number)
@@ -145,7 +157,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "validate correctly a block whose parent is in storage" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     blockchain.save(validBlockParent)
     blockHeaderValidator.validate(validBlockHeader, blockchain) match {
@@ -156,7 +169,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if the parent's header is not in storage" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     blockHeaderValidator.validate(validBlockHeader, blockchain) match {
       case Left(HeaderParentNotFoundError) => succeed
@@ -166,7 +180,8 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if the slot number is lower than it's parent's" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     val invalidBlockHeader = validBlockHeader.copy(slotNumber = validBlockParent.slotNumber - 1)
     blockHeaderValidator.validate(invalidBlockHeader, validBlockParent) shouldBe Left(HeaderSlotNumberError)
@@ -174,14 +189,16 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
 
   it should "return a failure if the block is from a future slot" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(true).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() + 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime - 1.millis).anyNumberOfTimes()
 
     blockHeaderValidator.validate(validBlockHeader, validBlockParent) shouldBe Left(HeaderSlotNumberError)
   }
 
   it should "return a failure if the block beneficiary wasn't the slot leader" in new TestSetup {
     (electionManagerMock.verifyIsLeader _).expects(*,*).returning(false).anyNumberOfTimes()
-    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(System.currentTimeMillis() - 1000).anyNumberOfTimes()
+    (slotCalculatorMock.getSlotStartingMillis _).expects(*).returning(CurrentTime.toMillis - 1).anyNumberOfTimes()
+    (clockMock.now _).expects().returning(CurrentTime).anyNumberOfTimes()
 
     val invalidBlockHeader = validBlockHeader.copy(slotNumber = validBlockParent.slotNumber - 1)
     blockHeaderValidator.validate(invalidBlockHeader, validBlockParent) shouldBe Left(HeaderBeneficiaryError)
@@ -198,8 +215,11 @@ class BlockHeaderValidatorSpec extends FlatSpec with Matchers with PropertyCheck
     val electionManagerMock = mock[ElectionManagerImpl]
     val slotCalculatorMock = mock[SlotTimeConverter]
 
-    val blockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig, electionManagerMock, slotCalculatorMock)
+    val clockMock = mock[Clock]
+    val blockHeaderValidator = new BlockHeaderValidatorImpl(blockchainConfig, electionManagerMock, slotCalculatorMock, clockMock)
     val difficultyCalculator = new DifficultyCalculator(blockchainConfig)
+
+    val CurrentTime = 2.millis
   }
 
   val pausedDifficultyBombBlock = BlockHeader(


### PR DESCRIPTION
## Description

Incorporates using NTP for obtaining the current time, that's being used for both mining and block validation. The NTP implementation is based on the [Scorex code](https://github.com/input-output-hk/Scorex/blob/master/scorex-basics/src/main/scala/scorex/utils/NTP.scala).

Also incorporates a fix to `SlotTimeConverter` test.