### PR TITLE
[PO-44] Return Block Signature in RPC Methods

### DIFF
--- a/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
+++ b/src/main/scala/io/iohk/ethereum/jsonrpc/BlockResponse.scala
@@ -1,6 +1,7 @@
 package io.iohk.ethereum.jsonrpc
 
 import akka.util.ByteString
+import io.iohk.ethereum.crypto.ECDSASignature
 import io.iohk.ethereum.domain.{Block, SignedBlockHeader}
 import io.iohk.ethereum.network.p2p.messages.PV62.BlockBody
 
@@ -23,7 +24,8 @@ case class BlockResponse(
     gasUsed: BigInt,
     timestamp: BigInt,
     transactions: Either[Seq[ByteString], Seq[TransactionResponse]],
-    uncles: Seq[ByteString])
+    uncles: Seq[ByteString],
+    signature: ECDSASignature)
 
 object BlockResponse {
 
@@ -56,7 +58,8 @@ object BlockResponse {
       gasUsed = block.signedHeader.header.gasUsed,
       timestamp = block.signedHeader.header.unixTimestamp,
       transactions = transactions,
-      uncles = block.body.uncleNodesList.map(_.hash)
+      uncles = block.body.uncleNodesList.map(_.hash),
+      signature = block.signedHeader.signature
     )
   }
 


### PR DESCRIPTION
The purpose of this PR is to make the appropriate changes in order for the following RPC methods to return the block signature:

- eth_getBlockByHash
- eth_getBlockByNumber
- eth_getUncleByBlockHashAndIndex
- eth_getUncleByBlockNumberAndIndex