### PR TITLE
Fix initial ouroboros config

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -440,11 +440,9 @@ mantis {
     # Used for dynamically changing the list of miner stakeholders, adding a new entry requires restarting the
     # client, the slot number of the new entry should be higher than the slot number from when
     # the client is restarted
-    slot-minerStakeHolders-mapping =
-      {
-        1:  ["edde8656c35fcb7126c61fc6e2673734425a72bf"],
-        20: ["240653414e3d40764a0fc75af372bb6458f8600a"]
-      }
+    slot-minerStakeHolders-mapping = {
+      1: ["edde8656c35fcb7126c61fc6e2673734425a72bf"]
+    }
 
     # Duration of each slot
     slot-duration = 15.seconds

--- a/src/universal/conf/ouroboros.conf
+++ b/src/universal/conf/ouroboros.conf
@@ -7,13 +7,11 @@ mantis {
     # Used for dynamically changing the list of miner stakeholders, adding a new entry requires restarting the
     # client, the slot number of the new entry should be higher than the slot number from when
     # the client is restarted
-    # slot-minerStakeHolders-mapping =
-    #   {
-    #     1:  ["edde8656c35fcb7126c61fc6e2673734425a72bf"],
-    #     20: ["240653414e3d40764a0fc75af372bb6458f8600a"]
-    #   }
+    # slot-minerStakeHolders-mapping = {
+    #   1: ["edde8656c35fcb7126c61fc6e2673734425a72bf"]
+    # }
 
     # Duration of each slot
-    # slot-duration = 5.seconds
+    # slot-duration = 15.seconds
   }
 }


### PR DESCRIPTION
The initial slot-minerStakeHolders-map MUST has only one entry, because when a user customize the map, the older map is merge it with the new one, and if the first one has more entries, these ones are maintained, causing unwanted effects.